### PR TITLE
add vscode setting files

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,7 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+# typescript with node 20
+FROM mcr.microsoft.com/devcontainers/typescript-node:1-20-bullseye

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+// See https://aka.ms/vscode-remote/devcontainer.json for format details.
+{
+	"name": "Node.js (latest LTS)",
+	"remoteUser": "root", // これを設定しないでnodeユーザー等で環境構築すると.ssh/以下がマウントされない
+	"dockerFile": "Dockerfile",
+	"runArgs": [
+		"-v",
+		"${env:HOME}${env:USERPROFILE}/.aws:/root/.aws",
+		"-v",
+		"${env:HOME}${env:USERPROFILE}/.ssh:/root/.ssh:ro"
+	],
+	// Uncomment the next line if you want to publish any ports.
+	"appPort": [8080],
+	// Uncomment the next line if you want to add in default container specific settings.json values
+	// "settings":  { "workbench.colorTheme": "Quiet Light" },
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"dbaeumer.vscode-eslint",
+				"esbenp.prettier-vscode",
+				"bradlc.vscode-tailwindcss",
+				"eamodio.gitlens",
+				"tomoki1207.vscode-input-sequence",
+				"oderwat.indent-rainbow",
+				"svelte.svelte-vscode"
+			]
+		}
+	}
+}

--- a/.devcontainer/vimrc
+++ b/.devcontainer/vimrc
@@ -1,0 +1,1 @@
+set encoding=utf-8

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+	"workbench.colorCustomizations": {
+		"titleBar.activeBackground": "#470f49",
+		"editor.background": "#1b061f"
+	},
+	"editor.formatOnSave": true,
+	"editor.defaultFormatter": "esbenp.prettier-vscode",
+	"prettier.requireConfig": true,
+	"editor.codeActionsOnSave": { "source.organizeImports": "explicit" }
+}


### PR DESCRIPTION
# add vscode settings

# summary

## 1. add .vscode/settings.json

  - change editor color
    ```
    "workbench.colorCustomizations": {
        "titleBar.activeBackground": "#470f49",
        "editor.background": "#1b061f"
    },
    ```
  - format with Prettier on save
     ```
     "editor.formatOnSave": true,
        "editor.defaultFormatter": "esbenp.prettier-vscode",
        "prettier.requireConfig": true,
        "editor.codeActionsOnSave": { "source.organizeImports": "explicit" }
     ```
## 2. add ./devcontainer/*

  - When you invoke the devcontainer plugin in the directory containing ./devcontainer, 
     a virtual environment will be created based on the configuration in ./devcontainer/Dockerfile.
  - ※ However, Docker for Desktop must be installed on the host.
  - ref:[Create a Dev Container](https://code.visualstudio.com/docs/devcontainers/create-dev-container)